### PR TITLE
Clean up diesel usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ project more or less adheres to
 
 ## Unreleased
 
-* (Nothing yet)
-
+* Clean up diesel usage.
+  - Use `belonging_to` and (rust-side) `grouped_by` to replace 1+n
+    queryes with 1+1 for loading tags on pages.
+  - the `post_tags` relation table does not need a separate `id` column.
+  - Use `Model::as_select()` instead of column tuples some places.
+  - Don't select the year for a post separately when getting the `posted_at`.
 
 ## Release 0.3.0
 2023-01-24 19:18 CST.

--- a/migrations/2023-02-19-194111_cleanup_post_tags/down.sql
+++ b/migrations/2023-02-19-194111_cleanup_post_tags/down.sql
@@ -1,0 +1,1 @@
+alter table post_tags add column id serial primary key;

--- a/migrations/2023-02-19-194111_cleanup_post_tags/up.sql
+++ b/migrations/2023-02-19-194111_cleanup_post_tags/up.sql
@@ -1,0 +1,2 @@
+alter table post_tags drop column id;
+alter table post_tags add primary key (post_id, tag_id);

--- a/src/listposts.rs
+++ b/src/listposts.rs
@@ -16,9 +16,7 @@ pub struct Args {
 
 impl Args {
     pub fn run(self) -> Result<()> {
-        let mut db = self.db.get_db()?;
-        let posts = PostLink::select().load::<PostLink>(&mut db)?;
-        for post in posts {
+        for post in PostLink::all().load(&mut self.db.get_db()?)? {
             println!(
                 "{:4}. {}{:18} {}",
                 post.id,

--- a/src/models/datetime.rs
+++ b/src/models/datetime.rs
@@ -1,3 +1,4 @@
+use chrono::Datelike;
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::sql_types::Timestamptz;
@@ -17,6 +18,10 @@ impl DateTime {
     }
     pub fn raw(&self) -> chrono::DateTime<chrono::Utc> {
         self.0
+    }
+
+    pub(crate) fn year(&self) -> i16 {
+        self.0.year() as i16
     }
 }
 

--- a/src/models/fullpost.rs
+++ b/src/models/fullpost.rs
@@ -30,7 +30,6 @@ impl FullPost {
             .select((
                 (
                     p::id,
-                    year_of_date(p::posted_at),
                     p::slug,
                     p::lang,
                     p::title,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -17,7 +17,7 @@ pub use self::markdown::safe_md2html;
 pub use self::post::Post;
 pub use self::postlink::PostLink;
 pub use self::slug::Slug;
-pub use self::tag::Tag;
+pub use self::tag::{PostTag, Tag};
 pub use self::teaser::Teaser;
 
 type Result<T, E = diesel::result::Error> = std::result::Result<T, E>;

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1,11 +1,11 @@
 use super::{DateTime, Slug, Tag};
+use crate::schema::posts;
 use i18n_embed::fluent::FluentLanguageLoader;
 use i18n_embed_fl::fl;
 
-#[derive(Debug, Queryable)]
+#[derive(Debug, Queryable, Identifiable)]
 pub struct Post {
     pub id: i32,
-    pub year: i16,
     pub slug: Slug,
     pub lang: String,
     pub title: String,
@@ -16,7 +16,10 @@ pub struct Post {
 
 impl Post {
     pub fn url(&self) -> String {
-        format!("/{}/{}.{}", self.year, self.slug, self.lang)
+        format!("/{}/{}.{}", self.year(), self.slug, self.lang)
+    }
+    pub fn year(&self) -> i16 {
+        self.posted_at.year()
     }
     pub fn publine(
         &self,

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -1,15 +1,24 @@
-use super::{Result, Slug};
+use super::{Post, Result, Slug};
 use crate::dbopt::Connection;
-use crate::schema::post_tags::dsl as pt;
-use crate::schema::tags::dsl as t;
+use crate::schema::{post_tags, tags};
+use diesel::associations::HasTable;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
-#[derive(Debug, Queryable)]
+#[derive(Identifiable, Debug, Selectable, Queryable, PartialEq)]
 pub struct Tag {
     pub id: i32,
     pub slug: Slug,
     pub name: String,
+}
+
+#[derive(Identifiable, Selectable, Queryable, Associations, Debug)]
+#[diesel(belongs_to(Tag))]
+#[diesel(belongs_to(Post))]
+#[diesel(primary_key(post_id, tag_id))]
+pub struct PostTag {
+    pub post_id: i32,
+    pub tag_id: i32,
 }
 
 impl Tag {
@@ -17,25 +26,10 @@ impl Tag {
         slug: &Slug,
         db: &mut Connection,
     ) -> Result<Option<Tag>> {
-        t::tags
-            .filter(t::slug.eq(slug.as_ref()))
+        Tag::table()
+            .filter(tags::slug.eq(slug.as_ref()))
             .first::<Tag>(db)
             .await
             .optional()
-    }
-    pub async fn for_post(
-        post_id: i32,
-        db: &mut Connection,
-    ) -> Result<Vec<Tag>> {
-        t::tags
-            .filter(
-                t::id.eq_any(
-                    pt::post_tags
-                        .select(pt::tag_id)
-                        .filter(pt::post_id.eq(post_id)),
-                ),
-            )
-            .load(db)
-            .await
     }
 }

--- a/src/models/teaser.rs
+++ b/src/models/teaser.rs
@@ -1,11 +1,13 @@
-use super::{has_lang, year_of_date, Post, Result, Tag};
+use super::{has_lang, year_of_date, Post, PostTag, Result, Tag};
 use crate::dbopt::Connection;
 use crate::schema::comments::dsl as c;
 use crate::schema::post_tags::dsl as pt;
 use crate::schema::posts::dsl as p;
+use diesel::associations::HasTable;
 use diesel::dsl::{not, sql};
 use diesel::prelude::*;
 use diesel::sql_types::BigInt;
+use diesel::BelongingToDsl;
 use diesel_async::RunQueryDsl;
 use i18n_embed_fl::fl;
 
@@ -31,7 +33,6 @@ impl Teaser {
             .select((
                 (
                     p::id,
-                    year_of_date(p::posted_at),
                     p::slug,
                     p::lang,
                     p::title,
@@ -52,19 +53,7 @@ impl Teaser {
             .limit(limit.into())
             .load::<(Post, bool, i64)>(db)
             .await?;
-        // Note: Doing this truly async would require a db pool, not just a
-        // connection.  Or can it all be done with a single query?
-        let mut result = Vec::with_capacity(posts.len());
-        for (post, is_more, n_comments) in posts {
-            let tags = Tag::for_post(post.id, db).await?;
-            result.push(Teaser {
-                post,
-                tags,
-                is_more,
-                n_comments: n_comments as _,
-            });
-        }
-        Ok(result)
+        Self::with_tags(posts, db).await
     }
     pub async fn for_year(
         year: i16,
@@ -79,7 +68,6 @@ impl Teaser {
             .select((
                 (
                     p::id,
-                    year_of_date(p::posted_at),
                     p::slug,
                     p::lang,
                     p::title,
@@ -104,19 +92,7 @@ impl Teaser {
             .order(p::updated_at.asc())
             .load::<(Post, bool, i64)>(db)
             .await?;
-        // Note: Doing this truly async would require a db pool, not just a
-        // connection.  Or can it all be done with a single query?
-        let mut result = Vec::with_capacity(posts.len());
-        for (post, is_more, n_comments) in posts {
-            let tags = Tag::for_post(post.id, db).await?;
-            result.push(Teaser {
-                post,
-                tags,
-                is_more,
-                n_comments: n_comments as _,
-            });
-        }
-        Ok(result)
+        Self::with_tags(posts, db).await
     }
 
     pub async fn tagged(
@@ -133,7 +109,6 @@ impl Teaser {
             .select((
                 (
                     p::id,
-                    year_of_date(p::posted_at),
                     p::slug,
                     p::lang,
                     p::title,
@@ -161,20 +136,32 @@ impl Teaser {
             .limit(limit.into())
             .load::<(Post, bool, i64)>(db)
             .await?;
-        // Note: Doing this truly async would require a db pool, not just a
-        // connection.  Or can it all be done with a single query?
-        let mut result = Vec::with_capacity(posts.len());
-        for (post, is_more, n_comments) in posts {
-            let tags = Tag::for_post(post.id, db).await?;
-            result.push(Teaser {
+        Self::with_tags(posts, db).await
+    }
+
+    async fn with_tags(
+        posts: Vec<(Post, bool, i64)>,
+        db: &mut Connection,
+    ) -> Result<Vec<Teaser>> {
+        let postrefs =
+            posts.iter().map(|(post, _, _)| post).collect::<Vec<_>>();
+        Ok(PostTag::belonging_to(&postrefs)
+            .inner_join(Tag::table())
+            .select((PostTag::as_select(), Tag::as_select()))
+            .load(db)
+            .await?
+            .grouped_by(&postrefs)
+            .into_iter()
+            .zip(posts)
+            .map(|(tags, (post, is_more, n_comments))| Teaser {
                 post,
-                tags,
+                tags: tags.into_iter().map(|(_, tag)| tag).collect(),
                 is_more,
                 n_comments: n_comments as _,
-            });
-        }
-        Ok(result)
+            })
+            .collect())
     }
+
     pub fn publine(&self) -> String {
         // TODO: Take the fluent as an argument instead?
         let lang = crate::server::language::load(&self.lang).unwrap();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -38,8 +38,7 @@ table! {
 }
 
 table! {
-    post_tags (id) {
-        id -> Int4,
+    post_tags (post_id, tag_id) {
         post_id -> Int4,
         tag_id -> Int4,
     }

--- a/src/server/comment.rs
+++ b/src/server/comment.rs
@@ -41,14 +41,11 @@ async fn postcomment(
     app.verify_csrf(&form.csrftoken, &csrf_cookie)?;
     let mut db = app.db().await?;
 
-    let post = form.post;
-    let post = PostLink::select()
-        .filter(p::id.eq(post))
-        .first::<PostLink>(&mut db)
+    let post = PostLink::all()
+        .filter(p::id.eq(form.post))
+        .first(&mut db)
         .await?;
 
-    let name = form.name.clone();
-    let email = form.email.clone();
     let url = form
         .url
         .as_ref()
@@ -63,8 +60,8 @@ async fn postcomment(
     let counts = c::comments
         .group_by((c::is_public, c::is_spam))
         .select(((c::is_public, c::is_spam), count_star()))
-        .filter(c::name.eq(name))
-        .filter(c::email.eq(email))
+        .filter(c::name.eq(&form.name))
+        .filter(c::email.eq(&form.email))
         .load::<((bool, bool), i64)>(&mut db)
         .await?;
     let mut public = 0;

--- a/templates/frontpage.rs.html
+++ b/templates/frontpage.rs.html
@@ -19,7 +19,7 @@
     </header>
     <main>
       @for post in posts {
-      <article id="post_@(post.year)_@post.slug" lang="@post.lang">
+      <article id="post_@(post.year())_@post.slug" lang="@post.lang">
         <h2><a href="@post.url()">@Html(&post.title)</a></h2>
         <p class="publine">@Html(post.publine())</p>
         @Html(&post.content)

--- a/templates/post.rs.html
+++ b/templates/post.rs.html
@@ -81,7 +81,7 @@
       <ul>@for link in similar {
         <li><a href="@link.url()" hreflang="@link.lang" lang="@link.lang">@Html(&link.title)</a> (@link.year)</li>
         }</ul>
-      <p>@Html(fl!(fluent, "morefrom", year=post.year))</p>
+      <p>@Html(fl!(fluent, "morefrom", year=post.year()))</p>
     </aside>
     }
     @:me_box_html(fluent)

--- a/templates/posts.rs.html
+++ b/templates/posts.rs.html
@@ -17,7 +17,7 @@
       <p class="tagline">@fl!(fluent, "tagline")</p>
 
       @for post in posts {
-      <article id="post_@(post.year)_@post.slug" lang="@post.lang">
+      <article id="post_@(post.year())_@post.slug" lang="@post.lang">
         <h2><a href="@post.url()">@Html(&post.title)</a></h2>
         <p class="publine">@Html(post.publine())</p>
         @Html(&post.content)


### PR DESCRIPTION
- Use `belonging_to` and (rust-side) `grouped_by` to replace 1+n queryes with 1+1 for loading tags on pages.
- the `post_tags` relation table does not need a separate `id` column.
- Use `Model::as_select()` instead of column tuples some places.
- Don't select the year for a post separately when getting the `posted_at`.
